### PR TITLE
Optionally open a particular notebook on startup

### DIFF
--- a/server/src/main/assets/from_ipython/static/js/csrf.js
+++ b/server/src/main/assets/from_ipython/static/js/csrf.js
@@ -31,7 +31,7 @@
         if (typeof(Storage) !== "undefined") {
            if (csrfKey) { /* Move the key into local storage */
                sessionStorage.csrfKey = csrfKey
-               document.cookie = CSRFToken + "=invalid; expires=Thu, 01 Jan 1970 00:00:01 GMT"
+               document.cookie = CSRFToken + "=invalid; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT"
            } else if (sessionStorage.csrfKey)
               csrfKey = sessionStorage.csrfKey
            else if (window.opener && window.opener.IPython) csrfKey = window.opener.IPython.CSRF.key


### PR DESCRIPTION
Pass a name as a parameter --notebook=name and the server will
redirect to /view/:name (urlencoded) after secure login.

This is useful for testing changes to scala-notebook, so that you can go directly from sbt to a notebook that uses the features you want to test.

Note: csrf.js would not delete the csrf cookie as expected when
loading from a non-root path, which would cause a websocket error;
this is fixed here.
