### PR TITLE
Update less.jsm

### DIFF
--- a/server/src/main/assets/thirdparty/static/less.jsm
+++ b/server/src/main/assets/thirdparty/static/less.jsm
@@ -1,1 +1,1 @@
-https://raw.github.com/cloudhead/less.js/master/dist/less-1.3.3.js
+http://cdnjs.cloudflare.com/ajax/libs/less.js/1.3.3/less.min.js


### PR DESCRIPTION
The location of the less file (https://raw.githubusercontent.com/cloudhead/less.js/master/dist/less-1.3.3.js) was throwing a java.io.FileNotFoundException because the cloudhead/less.js repository has apparently gone away. (curl https://raw.githubusercontent.com/cloudhead/less.js/master/dist/less-1.3.3.js ->
Not Found)

I don't know if there is a better place to get the file, but this CDN location works and allows the project to build
