### PR TITLE
Fix #42 (widgets broken)

### DIFF
--- a/observable/src/main/assets/observable/js/observable.js
+++ b/observable/src/main/assets/observable/js/observable.js
@@ -213,9 +213,9 @@ return new function () {
             var source = this.textContent;
             $(this).remove();
 
-            function require(requirements, callback) {
+            data.require = function (requirements, callback) {
               curl(requirements, function () { callback.apply(scope, arguments); });
-            }
+            };
 
             return function () { (function() { with (data) { eval(source); } }).call(scope); };
         });


### PR DESCRIPTION
Looks like the JS minification was removing the require function definition because it appeared to be unused.  Passing it in explicitly into the data context of the evaluation fixes this issue.